### PR TITLE
feat: add optional auto-collapsing toolbar

### DIFF
--- a/src/GCMainView.ts
+++ b/src/GCMainView.ts
@@ -190,6 +190,7 @@ export class GCMainView extends ItemView {
 			currentDate: this.currentDate,
 			titleText: this.getViewTitle(),
 			showViewNavButtonText: this.plugin?.settings?.showViewNavButtonText ?? true,
+			autoCollapse: this.plugin?.settings?.autoCollapseToolbar ?? false,
 			globalFilterText: this.plugin?.settings?.globalTaskFilter,
 			taskRenderer: this.taskRenderer,
 			ganttRenderer: this.ganttRenderer,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -139,6 +139,10 @@
 				"name": "Show Navigation Button Text",
 				"description": "Show text labels on view navigation buttons in the toolbar. When disabled, only icons are shown"
 			},
+			"autoCollapseToolbar": {
+				"name": "Auto-collapse Toolbar",
+				"description": "Collapse the toolbar to the current view button. Hover or focus it to reveal a vertical view menu and a horizontal action bar"
+			},
 			"language": {
 				"name": "Language",
 				"description": "Select the plugin interface language",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -139,6 +139,10 @@
 				"name": "视图导航按钮显示文本",
 				"description": "工具栏左侧的视图导航按钮是否显示文字标签。关闭后仅显示图标"
 			},
+			"autoCollapseToolbar": {
+				"name": "自动收起工具栏",
+				"description": "将工具栏收起为当前视图按钮；悬停或聚焦后显示纵向视图菜单和横向操作栏"
+			},
 			"language": {
 				"name": "语言",
 				"description": "选择插件界面语言",

--- a/src/settings/builders/GeneralSettingsBuilder.ts
+++ b/src/settings/builders/GeneralSettingsBuilder.ts
@@ -69,6 +69,18 @@ export class GeneralSettingsBuilder extends BaseBuilder {
 						}));
 			});
 
+			// 自动收起工具栏
+			addSetting(setting => {
+				setting.setName(i18n.t('settings.general.autoCollapseToolbar.name'))
+					.setDesc(i18n.t('settings.general.autoCollapseToolbar.description'))
+					.addToggle(toggle => toggle
+						.setValue(this.plugin.settings.autoCollapseToolbar)
+						.onChange((value) => {
+							this.plugin.settings.autoCollapseToolbar = value;
+							void this.saveAndRefreshViews();
+						}));
+			});
+
 			// 语言选择
 			addSetting(setting => {
 				setting.setName(i18n.t('settings.general.language.name'))

--- a/src/settings/constants.ts
+++ b/src/settings/constants.ts
@@ -38,6 +38,7 @@ export const DEFAULT_SETTINGS: GanttCalendarSettings = {
 	defaultTaskPriority: 'medium', // 默认中等优先级
 	enableDebugMode: false, // 默认关闭开发者模式
 	showViewNavButtonText: true, // 默认显示视图导航按钮文本
+	autoCollapseToolbar: false, // 默认保持完整工具栏，避免改变现有用户布局
 	timezoneOffset: null, // 默认跟随系统时区
 	timeFormat: '24h', // 默认24小时制
 			recurringTaskDisplayLimit: 5, // 默认显示5个虚拟实例

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -44,6 +44,7 @@ export interface GanttCalendarSettings {
 	defaultTaskPriority: 'highest' | 'high' | 'medium' | 'low' | 'lowest' | 'normal'; // 默认任务优先级
 	enableDebugMode: boolean; // 是否启用开发者模式（详细日志）
 	showViewNavButtonText: boolean; // 是否显示视图导航按钮文本
+	autoCollapseToolbar: boolean; // 是否将工具栏收起为当前视图按钮
 	timezoneOffset: number | null; // 时区偏移量（分钟），null 表示跟随系统
 	timeFormat: '24h' | '12h'; // 时间显示格式
 	recurringTaskDisplayLimit: number; // 周期任务虚拟实例显示数量上限

--- a/src/toolbar/toolbar.ts
+++ b/src/toolbar/toolbar.ts
@@ -24,6 +24,17 @@ export class Toolbar {
 	private rightTaskSection: ToolbarRightTask;
 	private rightGanttSection: ToolbarRightGantt;
 	private responsiveManager: ToolbarResponsiveManager;
+	private container: HTMLElement | null = null;
+	private isExpanded = false;
+	private currentViewType: CalendarViewType | null = null;
+	private openingTimer: number | null = null;
+	private activeDocument: Document | null = null;
+	private readonly handleDocumentPointerDown = (event: PointerEvent): void => {
+		if (!this.isExpanded || !this.container) return;
+		if (!this.container.contains(event.target as Node)) {
+			this.setExpanded(false);
+		}
+	};
 
 	constructor() {
 		this.leftSection = new ToolbarLeft();
@@ -32,6 +43,26 @@ export class Toolbar {
 		this.rightTaskSection = new ToolbarRightTask();
 		this.rightGanttSection = new ToolbarRightGantt();
 		this.responsiveManager = new ToolbarResponsiveManager();
+	}
+
+	private setExpanded(expanded: boolean, animate = false): void {
+		this.isExpanded = expanded;
+		if (!this.container) return;
+
+		this.container.toggleClass(ToolbarClasses.modifiers.expanded, expanded);
+		this.container.removeClass(ToolbarClasses.modifiers.opening);
+		if (this.openingTimer !== null) {
+			window.clearTimeout(this.openingTimer);
+			this.openingTimer = null;
+		}
+
+		if (expanded && animate) {
+			this.container.addClass(ToolbarClasses.modifiers.opening);
+			this.openingTimer = window.setTimeout(() => {
+				this.container?.removeClass(ToolbarClasses.modifiers.opening);
+				this.openingTimer = null;
+			}, 180);
+		}
 	}
 
 	/**
@@ -52,12 +83,29 @@ export class Toolbar {
 	 * @param config 工具栏配置
 	 */
 	render(container: HTMLElement, config: ToolbarConfig): void {
+		const nextDocument = container.ownerDocument;
+		if (this.activeDocument !== nextDocument) {
+			this.activeDocument?.removeEventListener('pointerdown', this.handleDocumentPointerDown, true);
+			nextDocument.addEventListener('pointerdown', this.handleDocumentPointerDown, true);
+			this.activeDocument = nextDocument;
+		}
+		this.container = container;
+		if (this.currentViewType !== null && this.currentViewType !== config.currentViewType) {
+			this.isExpanded = false;
+		}
+		this.currentViewType = config.currentViewType;
+		if (!config.autoCollapse) {
+			this.isExpanded = false;
+		}
+
 		container.empty();
 		container.addClass(ToolbarClasses.block);
 		container.toggleClass(
 			ToolbarClasses.modifiers.autoCollapse,
 			config.autoCollapse ?? false
 		);
+		container.toggleClass(ToolbarClasses.modifiers.expanded, this.isExpanded);
+		container.removeClass(ToolbarClasses.modifiers.opening);
 
 		// 创建三个区域容器
 		const leftContainer = container.createDiv(ToolbarClasses.elements.left);
@@ -65,10 +113,21 @@ export class Toolbar {
 		const rightContainer = container.createDiv(ToolbarClasses.elements.right);
 
 		// 渲染左侧6视图选择器
+		const handleViewSwitch = (type: CalendarViewType): void => {
+			if (config.autoCollapse) {
+				if (type === config.currentViewType) {
+					this.setExpanded(!this.isExpanded, !this.isExpanded);
+					return;
+				}
+				this.setExpanded(false);
+			}
+			config.onViewSwitch(type);
+		};
+
 		this.leftSection.render(
 			leftContainer,
 			config.currentViewType,
-			config.onViewSwitch,
+			handleViewSwitch,
 			config.showViewNavButtonText ?? true
 		);
 
@@ -118,6 +177,13 @@ export class Toolbar {
 	 */
 	destroy(): void {
 		this.responsiveManager.disconnect();
+		this.activeDocument?.removeEventListener('pointerdown', this.handleDocumentPointerDown, true);
+		this.activeDocument = null;
+		if (this.openingTimer !== null) {
+			window.clearTimeout(this.openingTimer);
+			this.openingTimer = null;
+		}
+		this.container = null;
 	}
 }
 

--- a/src/toolbar/toolbar.ts
+++ b/src/toolbar/toolbar.ts
@@ -54,6 +54,10 @@ export class Toolbar {
 	render(container: HTMLElement, config: ToolbarConfig): void {
 		container.empty();
 		container.addClass(ToolbarClasses.block);
+		container.toggleClass(
+			ToolbarClasses.modifiers.autoCollapse,
+			config.autoCollapse ?? false
+		);
 
 		// 创建三个区域容器
 		const leftContainer = container.createDiv(ToolbarClasses.elements.left);
@@ -126,6 +130,7 @@ export interface ToolbarConfig {
 	currentDate: Date;
 	titleText: string;
 	showViewNavButtonText?: boolean; // 是否显示视图导航按钮文本
+	autoCollapse?: boolean; // 是否自动收起工具栏
 
 	// 任务视图相关
 	globalFilterText?: string;

--- a/src/utils/bem.ts
+++ b/src/utils/bem.ts
@@ -399,6 +399,8 @@ export const ToolbarClasses = {
 		gantt: bem(BLOCKS.TOOLBAR, undefined, 'gantt'),
 		task: bem(BLOCKS.TOOLBAR, undefined, 'task'),
 		autoCollapse: bem(BLOCKS.TOOLBAR, undefined, 'auto-collapse'),
+		expanded: bem(BLOCKS.TOOLBAR, undefined, 'expanded'),
+		opening: bem(BLOCKS.TOOLBAR, undefined, 'opening'),
 		/** 响应式紧凑模式 - 左侧按钮只显示图标 */
 		compact: bem(BLOCKS.TOOLBAR, undefined, 'compact'),
 	},

--- a/src/utils/bem.ts
+++ b/src/utils/bem.ts
@@ -139,6 +139,7 @@ export const TaskCardClasses = {
 		dayView: bem(BLOCKS.TASK_CARD, undefined, 'day'),
 		taskView: bem(BLOCKS.TASK_CARD, undefined, 'task'),
 		ganttView: bem(BLOCKS.TASK_CARD, undefined, 'gantt'),
+		sidebarView: bem(BLOCKS.TASK_CARD, undefined, 'sidebar'),
 		// 状态修饰符
 		completed: bem(BLOCKS.TASK_CARD, undefined, 'completed'),
 		pending: bem(BLOCKS.TASK_CARD, undefined, 'pending'),
@@ -397,6 +398,7 @@ export const ToolbarClasses = {
 	modifiers: {
 		gantt: bem(BLOCKS.TOOLBAR, undefined, 'gantt'),
 		task: bem(BLOCKS.TOOLBAR, undefined, 'task'),
+		autoCollapse: bem(BLOCKS.TOOLBAR, undefined, 'auto-collapse'),
 		/** 响应式紧凑模式 - 左侧按钮只显示图标 */
 		compact: bem(BLOCKS.TOOLBAR, undefined, 'compact'),
 	},

--- a/styles.css
+++ b/styles.css
@@ -729,19 +729,19 @@ Author: sugar
 	display: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible)) .gc-toolbar__right,
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded) .gc-toolbar__right,
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded)
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn:not(.gc-toolbar__view-selector-btn--active) {
 	display: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible)) .gc-toolbar__view-selector-group {
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded) .gc-toolbar__view-selector-group {
 	padding: 0;
 	background: transparent;
 	box-shadow: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded)
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn--active {
 	height: 28px;
 	padding: 3px 8px;
@@ -749,30 +749,27 @@ Author: sugar
 	transform: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded)
 	.gc-toolbar__view-selector-btn--active .view-selector-btn-content {
 	gap: 3px;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
+.gc-toolbar--auto-collapse:not(.gc-toolbar--expanded)
 	.gc-toolbar__view-selector-btn--active .gc-toolbar__view-selector-icon {
 	width: 14px;
 	height: 14px;
 	font-size: 13px;
 }
 
-.gc-toolbar--auto-collapse:hover,
-.gc-toolbar--auto-collapse:has(:focus-visible) {
+.gc-toolbar--auto-collapse.gc-toolbar--expanded {
 	grid-template-columns: auto auto;
 	justify-items: start;
 	gap: 6px;
 	padding: 0;
 }
 
-.gc-toolbar--auto-collapse:hover .gc-toolbar__left,
-.gc-toolbar--auto-collapse:hover .gc-toolbar__right,
-.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__left,
-.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__right {
+.gc-toolbar--auto-collapse.gc-toolbar--expanded .gc-toolbar__left,
+.gc-toolbar--auto-collapse.gc-toolbar--expanded .gc-toolbar__right {
 	width: auto;
 	justify-content: flex-start;
 	padding: 4px;
@@ -785,8 +782,7 @@ Author: sugar
 	pointer-events: auto;
 }
 
-.gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-group,
-.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__view-selector-group {
+.gc-toolbar--auto-collapse.gc-toolbar--expanded .gc-toolbar__view-selector-group {
 	flex-direction: column;
 	align-items: stretch;
 	padding: 0;
@@ -794,23 +790,37 @@ Author: sugar
 	box-shadow: none;
 }
 
-.gc-toolbar--auto-collapse:hover
-	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn,
-.gc-toolbar--auto-collapse:has(:focus-visible)
+.gc-toolbar--auto-collapse.gc-toolbar--expanded
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn {
 	width: 100%;
 	justify-content: flex-start;
 }
 
-.gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-label,
-.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__view-selector-label {
+.gc-toolbar--auto-collapse.gc-toolbar--expanded .gc-toolbar__view-selector-label {
 	display: inline;
 }
 
-.gc-toolbar--auto-collapse:hover .gc-toolbar__right,
-.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__right {
+.gc-toolbar--auto-collapse.gc-toolbar--expanded .gc-toolbar__right {
 	max-width: calc(100cqw - 104px);
 	flex-wrap: nowrap;
+}
+
+.gc-toolbar--auto-collapse.gc-toolbar--opening .gc-toolbar__left {
+	animation: gc-toolbar-drop-down 160ms ease-out both;
+}
+
+.gc-toolbar--auto-collapse.gc-toolbar--opening .gc-toolbar__right {
+	animation: gc-toolbar-roll-right 160ms 20ms ease-out both;
+}
+
+@keyframes gc-toolbar-drop-down {
+	from { clip-path: inset(0 0 100% 0 round 11px); }
+	to { clip-path: inset(0 0 0 0 round 11px); }
+}
+
+@keyframes gc-toolbar-roll-right {
+	from { clip-path: inset(0 100% 0 0 round 11px); }
+	to { clip-path: inset(0 0 0 0 round 11px); }
 }
 
 /* ============================================

--- a/styles.css
+++ b/styles.css
@@ -693,6 +693,154 @@ Author: sugar
 }
 
 /* ============================================
+   可选：自动收起工具栏
+   收起时仅保留当前视图；展开后显示纵向视图菜单和横向操作栏
+   ============================================ */
+
+.view-content:has(> .gc-toolbar--auto-collapse) {
+	position: relative;
+	container-type: inline-size;
+}
+
+.calendar-toolbar.gc-toolbar--auto-collapse,
+.gc-toolbar.gc-toolbar--auto-collapse {
+	display: grid;
+	grid-template-columns: auto;
+	align-items: start;
+	gap: 0;
+	width: max-content;
+	max-width: calc(100cqw - 12px);
+	margin: 0;
+	padding: 2px;
+	position: absolute;
+	top: 2px;
+	left: 6px;
+	z-index: 120;
+	background: transparent;
+	border: 0;
+	box-shadow: none;
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+}
+
+.gc-toolbar--auto-collapse .gc-toolbar__center {
+	display: none;
+}
+
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within) .gc-toolbar__right,
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn:not(.gc-toolbar__view-selector-btn--active) {
+	display: none;
+}
+
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within) .gc-toolbar__view-selector-group {
+	padding: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn--active {
+	height: 28px;
+	padding: 3px 8px;
+	font-size: 11px;
+	transform: none;
+}
+
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+	.gc-toolbar__view-selector-btn--active .view-selector-btn-content {
+	gap: 3px;
+}
+
+.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+	.gc-toolbar__view-selector-btn--active .gc-toolbar__view-selector-icon {
+	width: 14px;
+	height: 14px;
+	font-size: 13px;
+}
+
+.gc-toolbar--auto-collapse:hover,
+.gc-toolbar--auto-collapse:focus-within {
+	grid-template-columns: auto auto;
+	justify-items: start;
+	gap: 6px;
+	padding: 0;
+}
+
+.gc-toolbar--auto-collapse:hover .gc-toolbar__left,
+.gc-toolbar--auto-collapse:hover .gc-toolbar__right,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__left,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
+	width: auto;
+	justify-content: flex-start;
+	padding: 4px;
+	border: 1px solid color-mix(in srgb, var(--background-modifier-border) 55%, transparent);
+	border-radius: 11px;
+	background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+	box-shadow: 0 5px 16px rgba(0, 0, 0, 0.12);
+	backdrop-filter: blur(16px) saturate(150%);
+	-webkit-backdrop-filter: blur(16px) saturate(150%);
+}
+
+.gc-toolbar--auto-collapse:hover .gc-toolbar__left,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__left {
+	transform-origin: center top;
+	animation: gc-toolbar-drop-down 170ms ease-out both;
+}
+
+.gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-group,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__view-selector-group {
+	flex-direction: column;
+	align-items: stretch;
+	padding: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.gc-toolbar--auto-collapse:hover
+	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn,
+.gc-toolbar--auto-collapse:focus-within
+	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn {
+	width: 100%;
+	justify-content: flex-start;
+}
+
+.gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-label,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__view-selector-label {
+	display: inline;
+}
+
+.gc-toolbar--auto-collapse:hover .gc-toolbar__right,
+.gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
+	max-width: calc(100cqw - 104px);
+	flex-wrap: nowrap;
+	transform-origin: left center;
+	animation: gc-toolbar-roll-right 170ms 35ms ease-out both;
+}
+
+@keyframes gc-toolbar-drop-down {
+	from {
+		opacity: 0;
+		transform: translateY(-8px) scaleY(0.86);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scaleY(1);
+	}
+}
+
+@keyframes gc-toolbar-roll-right {
+	from {
+		opacity: 0;
+		transform: translateX(-10px) scaleX(0.84);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0) scaleX(1);
+	}
+}
+
+/* ============================================
    工具栏组件样式 (BEM: gc-toolbar)
    ============================================ */
 

--- a/styles.css
+++ b/styles.css
@@ -721,6 +721,8 @@ Author: sugar
 	box-shadow: none;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
+	isolation: isolate;
+	transition: none;
 }
 
 .gc-toolbar--auto-collapse .gc-toolbar__center {
@@ -776,16 +778,16 @@ Author: sugar
 	padding: 4px;
 	border: 1px solid color-mix(in srgb, var(--background-modifier-border) 55%, transparent);
 	border-radius: 11px;
-	background: color-mix(in srgb, var(--background-primary) 88%, transparent);
+	background: var(--background-primary);
 	box-shadow: 0 5px 16px rgba(0, 0, 0, 0.12);
-	backdrop-filter: blur(16px) saturate(150%);
-	-webkit-backdrop-filter: blur(16px) saturate(150%);
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+	pointer-events: auto;
 }
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__left,
 .gc-toolbar--auto-collapse:focus-within .gc-toolbar__left {
-	transform-origin: center top;
-	animation: gc-toolbar-drop-down 170ms ease-out both;
+	animation: gc-toolbar-drop-down 130ms ease-out both;
 }
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-group,
@@ -814,29 +816,24 @@ Author: sugar
 .gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
 	max-width: calc(100cqw - 104px);
 	flex-wrap: nowrap;
-	transform-origin: left center;
-	animation: gc-toolbar-roll-right 170ms 35ms ease-out both;
+	animation: gc-toolbar-roll-right 130ms 20ms ease-out both;
 }
 
 @keyframes gc-toolbar-drop-down {
 	from {
-		opacity: 0;
-		transform: translateY(-8px) scaleY(0.86);
+		clip-path: inset(0 0 100% 0 round 11px);
 	}
 	to {
-		opacity: 1;
-		transform: translateY(0) scaleY(1);
+		clip-path: inset(0 0 0 0 round 11px);
 	}
 }
 
 @keyframes gc-toolbar-roll-right {
 	from {
-		opacity: 0;
-		transform: translateX(-10px) scaleX(0.84);
+		clip-path: inset(0 100% 0 0 round 11px);
 	}
 	to {
-		opacity: 1;
-		transform: translateX(0) scaleX(1);
+		clip-path: inset(0 0 0 0 round 11px);
 	}
 }
 

--- a/styles.css
+++ b/styles.css
@@ -729,19 +729,19 @@ Author: sugar
 	display: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within) .gc-toolbar__right,
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible)) .gc-toolbar__right,
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn:not(.gc-toolbar__view-selector-btn--active) {
 	display: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within) .gc-toolbar__view-selector-group {
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible)) .gc-toolbar__view-selector-group {
 	padding: 0;
 	background: transparent;
 	box-shadow: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn--active {
 	height: 28px;
 	padding: 3px 8px;
@@ -749,12 +749,12 @@ Author: sugar
 	transform: none;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
 	.gc-toolbar__view-selector-btn--active .view-selector-btn-content {
 	gap: 3px;
 }
 
-.gc-toolbar--auto-collapse:not(:hover):not(:focus-within)
+.gc-toolbar--auto-collapse:not(:hover):not(:has(:focus-visible))
 	.gc-toolbar__view-selector-btn--active .gc-toolbar__view-selector-icon {
 	width: 14px;
 	height: 14px;
@@ -762,7 +762,7 @@ Author: sugar
 }
 
 .gc-toolbar--auto-collapse:hover,
-.gc-toolbar--auto-collapse:focus-within {
+.gc-toolbar--auto-collapse:has(:focus-visible) {
 	grid-template-columns: auto auto;
 	justify-items: start;
 	gap: 6px;
@@ -771,8 +771,8 @@ Author: sugar
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__left,
 .gc-toolbar--auto-collapse:hover .gc-toolbar__right,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__left,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
+.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__left,
+.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__right {
 	width: auto;
 	justify-content: flex-start;
 	padding: 4px;
@@ -785,12 +785,8 @@ Author: sugar
 	pointer-events: auto;
 }
 
-.gc-toolbar--auto-collapse:hover .gc-toolbar__left,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__left {
-}
-
 .gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-group,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__view-selector-group {
+.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__view-selector-group {
 	flex-direction: column;
 	align-items: stretch;
 	padding: 0;
@@ -800,19 +796,19 @@ Author: sugar
 
 .gc-toolbar--auto-collapse:hover
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn,
-.gc-toolbar--auto-collapse:focus-within
+.gc-toolbar--auto-collapse:has(:focus-visible)
 	.gc-toolbar__view-selector-group button.gc-toolbar__view-selector-btn {
 	width: 100%;
 	justify-content: flex-start;
 }
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-label,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__view-selector-label {
+.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__view-selector-label {
 	display: inline;
 }
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__right,
-.gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
+.gc-toolbar--auto-collapse:has(:focus-visible) .gc-toolbar__right {
 	max-width: calc(100cqw - 104px);
 	flex-wrap: nowrap;
 }

--- a/styles.css
+++ b/styles.css
@@ -787,7 +787,6 @@ Author: sugar
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__left,
 .gc-toolbar--auto-collapse:focus-within .gc-toolbar__left {
-	animation: gc-toolbar-drop-down 130ms ease-out both;
 }
 
 .gc-toolbar--auto-collapse:hover .gc-toolbar__view-selector-group,
@@ -816,25 +815,6 @@ Author: sugar
 .gc-toolbar--auto-collapse:focus-within .gc-toolbar__right {
 	max-width: calc(100cqw - 104px);
 	flex-wrap: nowrap;
-	animation: gc-toolbar-roll-right 130ms 20ms ease-out both;
-}
-
-@keyframes gc-toolbar-drop-down {
-	from {
-		clip-path: inset(0 0 100% 0 round 11px);
-	}
-	to {
-		clip-path: inset(0 0 0 0 round 11px);
-	}
-}
-
-@keyframes gc-toolbar-roll-right {
-	from {
-		clip-path: inset(0 100% 0 0 round 11px);
-	}
-	to {
-		clip-path: inset(0 0 0 0 round 11px);
-	}
 }
 
 /* ============================================

--- a/tests/bem.test.ts
+++ b/tests/bem.test.ts
@@ -7,5 +7,7 @@ describe('BEM class mappings', () => {
 
 	it('maps the auto-collapse toolbar modifier', () => {
 		expect(ToolbarClasses.modifiers.autoCollapse).toBe('gc-toolbar--auto-collapse');
+		expect(ToolbarClasses.modifiers.expanded).toBe('gc-toolbar--expanded');
+		expect(ToolbarClasses.modifiers.opening).toBe('gc-toolbar--opening');
 	});
 });

--- a/tests/bem.test.ts
+++ b/tests/bem.test.ts
@@ -1,0 +1,11 @@
+import { TaskCardClasses, ToolbarClasses } from '../src/utils/bem';
+
+describe('BEM class mappings', () => {
+	it('maps the sidebar task-card modifier', () => {
+		expect(TaskCardClasses.modifiers.sidebarView).toBe('gc-task-card--sidebar');
+	});
+
+	it('maps the auto-collapse toolbar modifier', () => {
+		expect(ToolbarClasses.modifiers.autoCollapse).toBe('gc-toolbar--auto-collapse');
+	});
+});


### PR DESCRIPTION
## Summary

- add an opt-in **Auto-collapse Toolbar** setting under General settings
- collapse the toolbar to the active view button, then reveal a vertical view menu and horizontal action bar on hover or keyboard focus
- keep the collapsed toolbar floating so it does not reserve a full toolbar row
- add the missing `sidebarView` BEM mapping so Task List and Daily Timeline cards receive the existing compact sidebar styles

The setting defaults to off, preserving the current layout for existing users.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand tests/bem.test.ts` (2 passed)
- full test suite: 271 passed; 1 pre-existing failure in `TaskRepository.test.ts` because the Node test environment calls `window.setTimeout`
